### PR TITLE
fix: Add organigramme assets

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -8,9 +8,13 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy("source/**/*.svg");
   eleventyConfig.addPassthroughCopy("source/**/*.jpeg");
   eleventyConfig.addPassthroughCopy("source/**/*.png");
+  eleventyConfig.addPassthroughCopy("source/**/*.pdf");
+  eleventyConfig.addPassthroughCopy("source/**/*.csv");
+  eleventyConfig.addPassthroughCopy("source/**/*.xlsx");
+  eleventyConfig.addPassthroughCopy("source/**/*.docx");
+  eleventyConfig.addPassthroughCopy("source/**/*.json");
   eleventyConfig.addPassthroughCopy("source/**/*.geojson");
-  eleventyConfig.addPassthroughCopy("source/assets/file-download/");
-  eleventyConfig.addPassthroughCopy("source/assets/charts/");
+
   eleventyConfig.addPassthroughCopy("source/assets/allris/allris_streets.html");
   eleventyConfig.addPassthroughCopy("source/assets/fonts/");
   eleventyConfig.addPassthroughCopy("source/assets/css/*.css");
@@ -19,17 +23,14 @@ module.exports = function (eleventyConfig) {
 
   // grundsicherung files
   eleventyConfig.addPassthroughCopy(
-    "source/projekte/grundsicherung/data/*.csv"
-  );
-  eleventyConfig.addPassthroughCopy(
     "source/projekte/grundsicherung/src/fonts/*"
   );
   eleventyConfig.addPassthroughCopy("source/projekte/grundsicherung/js/*");
   eleventyConfig.addPassthroughCopy("source/projekte/grundsicherung/public/*");
   eleventyConfig.addPassthroughCopy("source/projekte/grundsicherung/*.css*");
-  eleventyConfig.addPassthroughCopy(
-    "source/projekte/grundsicherung/config.json"
-  );
+  // eleventyConfig.addPassthroughCopy(
+  // "source/projekte/grundsicherung/config.json"
+  // );
 
   // Return your Object options:
   return {


### PR DESCRIPTION
This makes 11ty copy more generic so more assets are copied over by default