### PR TITLE
fix(odis ressources): Removed .html from url

### DIFF
--- a/source/_data/ressourcen_odis.json
+++ b/source/_data/ressourcen_odis.json
@@ -9,14 +9,14 @@
             {
               "title": "Handout zum Thema Dateninventur",
               "source": "Dateninventur",
-              "url": "/ressourcen/dateninventur.html",
+              "url": "/ressourcen/dateninventur/",
               "text": "Um zu entscheiden welche Daten für eine Bereitstellung als Open Data geeignet sind, kann es sinnvoll sein sich eine Übersicht über alle vorhandenen Datensätze zu verschaffen und eine Dateninventur durchzuführen. Doch was genau ist eigentlich eine Dateninventur und wie wird sie durchgeführt? ODIS hat alle wichtigen Infos in einem Handout zusammengestellt.",
               "image": "page/process-01.svg"
             },
             {
               "title": "Vorlage für ein Dateninformationsblatt",
               "source": "Dateninformationsblatt",
-              "url": "/ressourcen/dateninformationsblatt.html",
+              "url": "/ressourcen/dateninformationsblatt/",
               "text": "Im Zuge der Dateninventur wird erfasst, welche Daten innerhalb einer Behörde, Abteilung oder Fachgruppe vorliegen. Die dabei gewonnen Informationen müssen strukturiert erfasst werden, um sie später leicht zusammenführen und austauschen zu können. ODIS hat deshalb eine Vorlage zur Dokumentation der Datenbestände entwickelt, die Sie als Grundlage für Ihre eigene Dateninventur verwenden können.",
               "image": "page/process-02.svg"
             }
@@ -28,14 +28,14 @@
             {
               "title": "Metadaten-Leitfaden und Vorlage",
               "source": "Metadaten-Leitfaden",
-              "url": "/ressourcen/metadaten.html",
+              "url": "/ressourcen/metadaten/",
               "text": "Die Metadaten eines Datensatzes beschreiben die eigentlichen Daten. Sie sind ein wichtiger Bestandteil jeder Open-Data-Veröffentlichung, denn ohne qualitative Metadaten kann weder die Transparenz noch eine nachhaltige Verwendbarkeit der Daten garantiert werden. Erfahren Sie hier was sie für die Angabe von Metadaten wissen sollten.",
               "image": "page/process-06.png"
             },
             {
               "title": "Tipps zum Thema Tags",
               "source": "Metadaten-Tags",
-              "url": "/ressourcen/tag_analyse.html",
+              "url": "/ressourcen/tag_analyse/",
               "text": "Damit Daten im Open Data Portal gezielt gefunden werden können, wird jeder Datensatz durch Schlüsselworte, die sogenannten Tags, beschrieben. Die Tags dienen außerdem dazu, thematisch zusammenhängende Datensätze miteinander zu vernetzen. Lesen Sie hier weshalb es wichtig ist \"gute\" Tags zu vergeben und was es dabei zu beachten gibt.",
               "image": "page/graph.svg"
             }
@@ -47,14 +47,14 @@
             {
               "title": "Veröffentlichungs-Checkliste",
               "source": "Veröffentlichungs-Check",
-              "url": "/ressourcen/checkliste.html",
+              "url": "/ressourcen/checkliste/",
               "text": "Um Daten als Open Data effektiv und nachhaltig zur Verfügung zustellen, sollten einige Aspekte vorangehend sichergestellt werden. Mit unserer Checkliste können Sie für jeden Datensatz überprüfen, ob dieser zur Veröffentlichung bereit ist, oder weitere Schritte notwendig sind.",
               "image": "ressourcenPlaceholder2.svg"
             },
             {
               "title": "Checkliste zur Datenschutzprüfung",
               "source": "Datenschutzprüfung",
-              "url": "/ressourcen/datenschutz.html",
+              "url": "/ressourcen/datenschutz/",
               "text": "Die Veröffentlichung von Daten setzt voraus, dass die Offenlegung nach dem geltenden (Datenschutz-)Recht zulässig ist. Mit dieser Checkliste können Sie prüfen, ob Ihre Daten unter Einhaltung des Datenschutzes veröffentlicht werden können.",
               "image": "page/process-07.svg"
             }
@@ -66,7 +66,7 @@
             {
               "title": "Video-Tutorial zur Geocodierung",
               "source": "Daten zu Geodaten machen",
-              "url": "/ressourcen/geocodierung.html",
+              "url": "/ressourcen/geocodierung/",
               "text": "Der Großteil aller Verwaltungsdaten hat einen geographischen Bezug. Das können Adressen sein oder Informationen, die sich auf bestimmte Räume wie Bezirke oder Planungsräume beziehen. Um die Nutzung zu erleichtern, sollten diese Daten um Koordinaten ergänzt werden. Das ist leichter als gedacht. In unserem Video-Tutorial zeigen wir, wie Sie einen Datensatz mithilfe eines Webtools geocodieren können.",
               "image": "page/geo_marker.svg"
             }
@@ -78,7 +78,7 @@
             {
               "title": "Video-Tutorial zum Datenregister",
               "source": "Veröffentlichung im Datenportal",
-              "url": "/ressourcen/datenregister.html",
+              "url": "/ressourcen/datenregister/",
               "text": "Das Berliner Datenportal ist die zentrale Plattform für alle offenen Datensätze der Stadt. Erfahren Sie welche Möglichkeiten es gibt, um Daten im Portal zu veröffentlichen. Wir erklären ihnen Schritt-für-Schritt, wie Sie (Meta)-Daten über das sogenannte Datenregister eintragen und bearbeiten und geben Tipps, wie sie Ihre Daten besonders gut auffindbar machen.",
               "image": "page/logo-opendata.svg"
             }
@@ -90,7 +90,7 @@
             {
               "title": "Video-Tutorials zur Datenvisualisierung",
               "source": "Datenvisualisierung",
-              "url": "/ressourcen/datenvisualisierung.html",
+              "url": "/ressourcen/datenvisualisierung/",
               "text": "Open-Data ist kein Selbstzweck an sich, sondern dient in erster Linie dazu, Informationen einer breiten Masse zugänglich zu machen. Gut gemachte Datenvisualisierungen sind ein wichtiges Mittel, um Beobachtungen, Analysen und Erkenntnisse aus Daten auf einfache Art und Weise zu präsentieren. Sehen Sie hier was es dabei zu beachten gibt und wie sie mittels des kostenlosen Visualisierungs-Tools Datawrapper eigene Graphen und Karten erstellen können.",
               "image": "page/process-03.svg"
             }


### PR DESCRIPTION
The json file ressourcen_odis.json still had the urls pointing at the
old subpages where there was a html in the url. Since we changed that
generate folders with /index.html the links in that file where broken.