### PR TITLE
#ODISPROJ-282 Delete general reference to ideation lab site

### DIFF
--- a/source/projekte/index.html
+++ b/source/projekte/index.html
@@ -36,12 +36,5 @@ title: Projekte
             {% endfor %}
         </div>
 
-<!-- TODO: [ODISPROJ-282] project overview page references lab site. But the lab site is read only and won't be updated -->
-        <h4 class="headline-04 mb-4 mt-5">
-            Weitere Beispiele und Ressourcen rund um Open Data finden Sie auf der Seite des <br
-                class="conditional-break">
-            <a class="cross-link" href="https://lab.technologiestiftung-berlin.de/">Ideation & Prototyping Lab</a> der
-            Technologiestiftung Berlin.
-        </h4>
     </div>
 


### PR DESCRIPTION
remove the general reference to the the Ideation & Prototyping Lab site since it is not longer updated and all ODIS-related projects are individually linked anyways