### PR TITLE
ci: make build run against main not master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:


### PR DESCRIPTION
Since we renamed the default branch some time ago this action wont run if this is not applied.