### PR TITLE
feat(button): Add button component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,13 +12,15 @@
         "@11ty/eleventy": "2.0.0",
         "@11ty/eleventy-plugin-syntaxhighlight": "4.0.0",
         "@shopify/prettier-plugin-liquid": "1.2.2",
+        "@tailwindcss/container-queries": "0.1.1",
         "eslint": "8.10.0",
         "eslint-config-prettier": "8.5.0",
         "eslint-plugin-prettier": "4.0.0",
         "npm-run-all": "4.1.5",
         "prettier": "3.0.2",
         "prettier-plugin-tailwindcss": "0.5.3",
-        "tailwindcss": "3.2.4"
+        "tailwindcss": "3.2.4",
+        "tailwindcss-touch": "1.0.1"
       }
     },
     "node_modules/@11ty/dependency-tree": {
@@ -342,6 +344,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@tailwindcss/container-queries": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/container-queries/-/container-queries-0.1.1.tgz",
+      "integrity": "sha512-p18dswChx6WnTSaJCSGx6lTmrGzNNvm2FtXmiO6AuA1V4U5REyoqwmT6kgAsIMdjo07QdAfYXHJ4hnMtfHzWgA==",
+      "dev": true,
+      "peerDependencies": {
+        "tailwindcss": ">=3.2.0"
       }
     },
     "node_modules/@types/minimatch": {
@@ -4456,6 +4467,12 @@
       "peerDependencies": {
         "postcss": "^8.0.9"
       }
+    },
+    "node_modules/tailwindcss-touch": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss-touch/-/tailwindcss-touch-1.0.1.tgz",
+      "integrity": "sha512-h8A/S9+Mk2rnnaOB/NGCE7CxDhtGKbsAWf8Y2tCO6Zf381Y8dKcygPl1OXkFDnWXkL+FfHxmrGpwculDWAumbA==",
+      "dev": true
     },
     "node_modules/tailwindcss/node_modules/color-name": {
       "version": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -39,12 +39,14 @@
     "@11ty/eleventy": "2.0.0",
     "@11ty/eleventy-plugin-syntaxhighlight": "4.0.0",
     "@shopify/prettier-plugin-liquid": "1.2.2",
+    "@tailwindcss/container-queries": "0.1.1",
     "eslint": "8.10.0",
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-prettier": "4.0.0",
     "npm-run-all": "4.1.5",
     "prettier": "3.0.2",
     "prettier-plugin-tailwindcss": "0.5.3",
-    "tailwindcss": "3.2.4"
+    "tailwindcss": "3.2.4",
+    "tailwindcss-touch": "1.0.1"
   }
 }

--- a/source/_includes/button.liquid
+++ b/source/_includes/button.liquid
@@ -5,30 +5,43 @@
       font-bold
       {% if inverted %}
         shadow-primary-inv bg-bg text-links
+        hover-hover:hover:shadow-primary-inv-md
       {% else %}
         shadow-primary
+        hover-hover:hover:shadow-primary-md
       {% endif %}
     {% endif %}
     {% if variant == 'secondary' %}
       {% if inverted %}
         shadow-secondary-inv bg-bg-inv text-links-inv
+        hover-hover:hover:shadow-secondary-inv-md
       {% else %}
         shadow-secondary
+        hover-hover:hover:shadow-secondary-md
       {% endif %}
     {% endif %}
     {% if inverted %}
       border-line-inv
+      focus-visible:ring-offset-bg-inv
     {% else %}
       border-line text-links bg-bg
+      focus-visible:ring-offset-bg
     {% endif %}
+    hover-hover:hover:text-links
+    hover-hover:hover:bg-bg-alt
     inline-block py-4 px-6 mt-8 border-2
+    transition motion-reduce:transition-none
+    focus-visible:outline-none focus-visible:ring-4
+    focus-visible:ring-links/50
+    focus-visible:shadow-none
+    hover-hover:hover:focus-visible:shadow-none
+    focus-visible:ring-offset-4
+    cursor-pointer
   "
 
+  href="{{href}}"
   {% if id %}
     id="{{id}}"
-  {% endif %}
-  {% if href %}
-    href="{{href}}"
   {% endif %}
   {% if rel %}
     rel="{{rel}}"

--- a/source/_includes/button.liquid
+++ b/source/_includes/button.liquid
@@ -1,0 +1,50 @@
+<{{ tag | default: 'a' }}
+  class="
+    {% if class %}{{ class }} {% endif %}
+    {% if variant == 'primary' or variant == blank %}
+      font-bold
+      {% if inverted %}
+        shadow-primary-inv bg-bg text-links
+      {% else %}
+        shadow-primary
+      {% endif %}
+    {% endif %}
+    {% if variant == 'secondary' %}
+      {% if inverted %}
+        shadow-secondary-inv bg-bg-inv text-links-inv
+      {% else %}
+        shadow-secondary
+      {% endif %}
+    {% endif %}
+    {% if inverted %}
+      border-line-inv
+    {% else %}
+      border-line text-links bg-bg
+    {% endif %}
+    inline-block py-4 px-6 mt-8 border-2
+  "
+
+  {% if id %}
+    id="{{id}}"
+  {% endif %}
+  {% if href %}
+    href="{{href}}"
+  {% endif %}
+  {% if rel %}
+    rel="{{rel}}"
+  {% endif %}
+  {% if target %}
+    target="{{target}}"
+  {% endif %}
+  {% if title %}
+    title="{{title}}"
+  {% endif %}
+  {% if download %}
+    download="{{download}}"
+  {% endif %}
+  {% if ariaLabel %}
+    aria-label="{{ariaLabel}}"
+  {% endif %}
+>
+  {{ text }}
+</{{ tag | default: 'a' }}>

--- a/source/_includes/text-link.liquid
+++ b/source/_includes/text-link.liquid
@@ -1,0 +1,42 @@
+<{{ tag | default: 'a' }}
+  class="
+    {% if class %}{{ class }} {% endif %}
+    {% if inverted %}
+      text-links-inv border-line-inv
+      focus-visible:ring-offset-bg-inv
+      hover-hover:hover:text-text-inv
+      hover-hover:hover:border-links-active-inv
+    {% else %}
+      text-links border-line
+      focus-visible:ring-offset-bg
+      hover-hover:hover:text-links-active
+      hover-hover:hover:border-links-active
+    {% endif %}
+    inline-block pb-1 leading-tight border-b-8
+    focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-links/50
+    focus-visible:ring-offset-8
+    transition motion-reduce:transition-none
+  "
+
+  href="{{href}}"
+  {% if id %}
+    id="{{id}}"
+  {% endif %}
+  {% if rel %}
+    rel="{{rel}}"
+  {% endif %}
+  {% if target %}
+    target="{{target}}"
+  {% endif %}
+  {% if title %}
+    title="{{title}}"
+  {% endif %}
+  {% if download %}
+    download="{{download}}"
+  {% endif %}
+  {% if ariaLabel %}
+    aria-label="{{ariaLabel}}"
+  {% endif %}
+>
+  {{ text }}
+</{{ tag | default: 'a' }}>

--- a/source/assets/css/tailwind.css
+++ b/source/assets/css/tailwind.css
@@ -64,12 +64,12 @@
 
     --line: var(--blue);
     --line-dark: var(--blue-dark);
-    --line-inv: var(--blue-light);
+    --line-inv: var(--white);
     --line-dark-inv: var(--blue-light);
 
     --shadow-primary: var(--blue);
     --shadow-secondary: var(--blue-light);
-    --shadow-primary-inv: var(--blue-dark);
+    --shadow-primary-inv: var(--blue-darker);
     --shadow-secondary-inv: var(--blue-dark);
   }
 

--- a/source/assets/css/tailwind.css
+++ b/source/assets/css/tailwind.css
@@ -64,7 +64,7 @@
 
     --line: var(--blue);
     --line-dark: var(--blue-dark);
-    --line-inv: var(--white);
+    --line-inv: var(--blue-light);
     --line-dark-inv: var(--blue-light);
 
     --shadow-primary: var(--blue);

--- a/source/index.liquid
+++ b/source/index.liquid
@@ -4,7 +4,7 @@ title: Open Data Informationsstelle Berlin
 ---
 <div class="flex flex-col items-center">
   <!-- header -->
-  <section class="flex flex-col w-1/2 text-text">
+  <section class="flex flex-col items-start w-1/2 text-text">
     <h1 class="text-headlines">
       Offene Daten <br>
       für ein offenes Berlin
@@ -16,11 +16,8 @@ title: Open Data Informationsstelle Berlin
       Daten begleiten uns jeden Tag.
     </p>
 
-    <a
-      class="p-4 mt-8 border-2 border-line bg-bg shadow-primary w-40"
-      href=""
-      >Über ODIS
-    </a>
+    {% include 'button.liquid', text: 'Über ODIS' %}
+    {% include 'button.liquid', text: 'Über ODIS', variant: 'secondary' %}
   </section>
 
   <!-- map -->
@@ -95,17 +92,13 @@ title: Open Data Informationsstelle Berlin
         </div>
       </div>
 
-      <a
-        class="p-4 mt-8 border-2 border-line bg-bg drop-shadow-primary w-40"
-        href=""
-        >ODIS Blog erkunden</a
-      >
+      {% include 'button.liquid', text: 'ODIS Blog erkunden' %}
     </div>
   </div>
 
   <!-- aktuelles von der odis -->
   <div class="bg-bg-inv flex justify-center py-20">
-    <div class="flex flex-col w-1/2">
+    <div class="flex flex-col w-1/2 items-start">
       <h2 class="text-headlines-inv">Aktuelles von der ODIS</h2>
       <p class="text-text-inv 20">
         Die seit 2018 bestehende Open Data Informationsstelle unterstüzt die Berliner Verwaltung bei der Bereitstellung
@@ -121,11 +114,8 @@ title: Open Data Informationsstelle Berlin
         >
         <img src="/assets/images/platzhalter.png" alt="project card">
       </div>
-      <a
-        class="p-4 mt-8 border-2 border-line-inv bg-bg-inv drop-shadow-primary-inv text-links-inv w-60"
-        href=""
-        >Alle Projekte ansehen</a
-      >
+      {% include 'button.liquid', text: 'Alle Projekte ansehen', inverted: true %}
+      {% include 'button.liquid', text: 'Alle Projekte ansehen', inverted: true, variant: 'secondary' %}
     </div>
   </div>
 </div>

--- a/source/index.liquid
+++ b/source/index.liquid
@@ -18,6 +18,8 @@ title: Open Data Informationsstelle Berlin
 
     {% include 'button.liquid', text: 'Über ODIS' %}
     {% include 'button.liquid', text: 'Über ODIS', variant: 'secondary' %}
+    <br>
+    {% include 'text-link.liquid', text: 'Über ODIS' %}
   </section>
 
   <!-- map -->
@@ -116,6 +118,8 @@ title: Open Data Informationsstelle Berlin
       </div>
       {% include 'button.liquid', text: 'Alle Projekte ansehen', inverted: true %}
       {% include 'button.liquid', text: 'Alle Projekte ansehen', inverted: true, variant: 'secondary' %}
+      <br>
+      {% include 'text-link.liquid', text: 'Über ODIS', inverted: true %}
     </div>
   </div>
 </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -98,6 +98,7 @@ module.exports = {
 
 function getShadows() {
   return {
+    none: "0 0 0 transparent",
     ...getColorVariants("primary"),
     ...getColorVariants("secondary"),
     ...getColorVariants("primary-inv"),
@@ -109,9 +110,9 @@ function getColorVariants(variant) {
   return {
     [`${variant}-sm`]: `4px 4px 0 var(--shadow-${variant})`,
     [`${variant}`]: `8px 8px 0 var(--shadow-${variant})`,
-    [`${variant}-md`]: `16px 16px 0 var(--shadow-${variant})`,
-    [`${variant}-lg`]: `24px 24px 0 var(--shadow-${variant})`,
-    [`${variant}-xl`]: `32px 32px 0 var(--shadow-${variant})`,
-    [`${variant}-2xl`]: `40px 40px 0 var(--shadow-${variant})`,
+    [`${variant}-md`]: `12px 12px 0 var(--shadow-${variant})`,
+    [`${variant}-lg`]: `16px 16px 0 var(--shadow-${variant})`,
+    [`${variant}-xl`]: `18px 18px 0 var(--shadow-${variant})`,
+    [`${variant}-2xl`]: `24px 24px 0 var(--shadow-${variant})`,
   };
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,6 @@
 /** @type {import('tailwindcss').Config} */
+const plugin = require("tailwindcss/plugin");
+
 module.exports = {
   content: ["./**/*.{liquid,html}"],
   theme: {
@@ -81,7 +83,17 @@ module.exports = {
     boxShadow: getShadows(),
     dropShadow: getShadows()
   },
-  plugins: [],
+  plugins: [
+    require("@tailwindcss/container-queries"),
+    require("tailwindcss-touch")(),
+    plugin(function ({ addUtilities }) {
+      addUtilities({
+        ".text-balance": {
+          "text-wrap": "balance",
+        },
+      });
+    }),
+  ],
 };
 
 function getShadows() {


### PR DESCRIPTION
It was a pain to work with liquid but I finally did it. This new button component accepts the following props:
- tag (Html tag to use, defaults to anchor)
- text: The button text content
- variant: One of 'primary' or 'secondary'
- inverted: Whether the button is on an inverted background
- And those typical html props:
  - href
  - rel
  - download
  - title
  - aria-label
  - target
  - id